### PR TITLE
use /usr/bin/env bash in libcss parser-wrapper for cross-compatiblity

### DIFF
--- a/contrib/libcss/src/parse/properties/parser_wrapper.sh
+++ b/contrib/libcss/src/parse/properties/parser_wrapper.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# -lt 3 ]]; then
 	echo "Requires at least three arguments (output directory, gen_parser binary location, properties.gen location)"


### PR DESCRIPTION
This is a fix for building neosurf on Alpine Linux, which doesn't use bash by default, and has bash at /bin/bash when it is installed. Using /usr/bin/env bash should help keep things more widely compatible between operating systems and Linux distros.