### PR TITLE
add shift+space keyboard shortcuts to move up one screen

### DIFF
--- a/frontends/gtk/res/accelerators
+++ b/frontends/gtk/res/accelerators
@@ -38,3 +38,5 @@ gtkAddBookMarks:<Control>d
 gtkShowBookMarks:F6
 gtkShowCookies:F9
 gtkOpenLocation:<Control>l
+ScrollPDown:<space>
+ScrollPUp:<shift><space>

--- a/frontends/visurf/main.c
+++ b/frontends/visurf/main.c
@@ -1120,6 +1120,7 @@ nsvi_init_bindings(struct nsvi_state *state, struct nsvi_bindings *bindings)
 	nsvi_bindings_new(bindings, "<Home>", "scroll -p 0%");
 	nsvi_bindings_new(bindings, "<End>", "scroll -p 100%");
 	nsvi_bindings_new(bindings, "<space>", "scroll 100%-");
+	nsvi_bindings_new(bindings, "<C-space>", "scroll 100%+");
 	nsvi_bindings_new(bindings, "<plus>", "zoom 10%+");
 	nsvi_bindings_new(bindings, "<minus>", "zoom 10%-");
 	nsvi_bindings_new(bindings, "<equal>", "zoom 1");


### PR DESCRIPTION
In Neosurf, `space` moves the view one page down but `Shift+space` does not move the view one page up. Other browsers implement this feature and it feels like it would be easy to implement, but I can't figure it out. Currently this does not work.

Closes #20 