### PR TITLE
Specify OpenSSL 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ At build-time, NeoSurf requires the following programs:
 
 At runtime and build-time, the following libraries and their development headers are required:
 * libcurl
-* OpenSSL or LibreSSL (libcrypto, libssl)
+* OpenSSL 3.x or LibreSSL (libcrypto, libssl)
 * libpsl
 * libxml2
 * libjpeg, libjpeg-turbo or mozjpeg (optional)


### PR DESCRIPTION
Related to https://github.com/CobaltBSD/neosurf/issues/22

Just adds the requirement of OpenSSL 3.x to the readme as it will not build with 1.x.