### PR TITLE
Fix missing #include

### DIFF
--- a/contrib/libdom/bindings/xml/xmlparser.c
+++ b/contrib/libdom/bindings/xml/xmlparser.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #include <libxml/parser.h>
 #include <libxml/SAX2.h>


### PR DESCRIPTION
Compilation fails on Arch Linux, using https://aur.archlinux.org/packages/neosurf-git